### PR TITLE
Fix missing SecurityProtocol for Clickatell API

### DIFF
--- a/SmsAndCallClient/SmsAndCallClient/Api/ClickatellWrapperClient.cs
+++ b/SmsAndCallClient/SmsAndCallClient/Api/ClickatellWrapperClient.cs
@@ -32,6 +32,8 @@ namespace MatthiWare.SmsAndCallClient.Api
         public void Init()
         {
             IsInitialized = true;
+
+            ServicePointManager.SecurityProtocol |= (SecurityProtocolType)3072;
         }
 
         public override string ToString()


### PR DESCRIPTION
Fixes #1 & #2 

Adding TLS 1.2 fixes the above issues. 
`ServicePointManager.SecurityProtocol |= (SecurityProtocolType)3072;`